### PR TITLE
[#176147179] remove QueueStorageConnection from config

### DIFF
--- a/env.example
+++ b/env.example
@@ -4,7 +4,6 @@ COSMOSDB_PORT=3000
 API_GATEWAY_PORT=80
 
 FUNCTIONS_WORKER_RUNTIME=node
-QueueStorageConnection=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://fnstorage:10000/devstoreaccount1;QueueEndpoint=http://fnstorage:10001/devstoreaccount1;TableEndpoint=http://fnstorage:10002/devstoreaccount1;
 AzureWebJobsStorage=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://fnstorage:10000/devstoreaccount1;QueueEndpoint=http://fnstorage:10001/devstoreaccount1;TableEndpoint=http://fnstorage:10002/devstoreaccount1;
 FUNCTIONS_V2_COMPATIBILITY_MODE=true
 

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -36,7 +36,6 @@ export const IConfig = t.intersection([
     COSMOSDB_API_URI: NonEmptyString,
 
     AzureWebJobsStorage: NonEmptyString,
-    QueueStorageConnection: NonEmptyString,
 
     ENABLE_NOTICE_EMAIL_CACHE: t.boolean,
 

--- a/utils/healthcheck.ts
+++ b/utils/healthcheck.ts
@@ -142,7 +142,7 @@ export const checkApplicationHealth = (): HealthCheck<ProblemSource, true> =>
           config.COSMOSDB_API_URI,
           config.COSMOSDB_API_KEY
         ),
-        checkAzureStorageHealth(config.QueueStorageConnection)
+        checkAzureStorageHealth(config.AzureWebJobsStorage)
       )
     )
     .map(_ => true);


### PR DESCRIPTION
Remove reference to `QueueStorageConnection` env variable and use `AzureWebJobsStorage` instead.

This PR make this obsolete: https://github.com/pagopa/io-infrastructure-live-new/pull/355