### PR TITLE
Fix Client SDK Generation

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -37,7 +37,7 @@ resources:
     - repository: pagopaCommons
       type: github
       name: pagopa/azure-pipeline-templates
-      ref: refs/tags/v11
+      ref: refs/tags/v12
       endpoint: 'pagopa'
 
 stages:
@@ -190,3 +190,4 @@ stages:
         - template: templates/client-sdk-publish/template.yaml@pagopaCommons
           parameters:
             openapiSpecPath: 'openapi/index.yaml'
+            generatorPackageName: italia-utils           


### PR DESCRIPTION
Use _italia-utils_ as client SDK generation template instead of _@pagopa/openapi-codegen-ts_, to avoid generation errors